### PR TITLE
feat(datafusion): basic FileOpener impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,15 +11,15 @@ rust-version = "1.62"
 
 [dependencies]
 async-trait = { version = "0.1.53" }
-itertools = { version = "0.12.0"}
+itertools = { version = "0.12.0" }
 regex = { version = "1.9.5" }
 serde_json = { version = "1.0.107" }
-serde = {version = "1.0.188", features = ["derive"]}
-flate2 = { version = "1.0.27"}
+serde = { version = "1.0.188", features = ["derive"] }
+flate2 = { version = "1.0.27" }
 blosc = { version = "0.2.0" }
 crc32c = { version = "0.6.5" }
 object_store = { version = "0.9" }
-futures = { version = "0.3"}
+futures = { version = "0.3" }
 futures-util = { version = "0.3.30" }
 tokio = { version = "1.0" }
 dyn-clone = { version = "1.0.16" }
@@ -29,6 +29,12 @@ arrow-buffer = { version = "50.0.0" }
 arrow-cast = { version = "50.0.0" }
 arrow-schema = { version = "50.0.0" }
 arrow-data = { version = "50.0.0" }
+datafusion = { version = "36.0", optional = true }
+
+[features]
+datafusion = ["dep:datafusion"]
+all = ["datafusion"]
 
 [dev-dependencies]
 arrow-cast = { version = "50.0.0", features = ["prettyprint"] }
+chrono = { version = "0.4" }

--- a/src/datafusion/config.rs
+++ b/src/datafusion/config.rs
@@ -24,3 +24,9 @@ pub struct ZarrConfig {
     // The object store to use.
     pub object_store: Arc<dyn ObjectStore>,
 }
+
+impl ZarrConfig {
+    pub fn new(object_store: Arc<dyn ObjectStore>) -> Self {
+        Self { object_store }
+    }
+}

--- a/src/datafusion/config.rs
+++ b/src/datafusion/config.rs
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use object_store::ObjectStore;
+
+#[derive(Clone)]
+pub struct ZarrConfig {
+    // The object store to use.
+    pub object_store: Arc<dyn ObjectStore>,
+}

--- a/src/datafusion/file_opener.rs
+++ b/src/datafusion/file_opener.rs
@@ -1,0 +1,105 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow_schema::ArrowError;
+use datafusion::{datasource::physical_plan::FileOpener, error::DataFusionError};
+use futures::{StreamExt, TryStreamExt};
+
+use crate::async_reader::{ZarrPath, ZarrRecordBatchStreamBuilder};
+
+use super::config::ZarrConfig;
+
+pub struct ZarrFileOpener {
+    config: ZarrConfig,
+}
+
+impl ZarrFileOpener {
+    pub fn new(config: ZarrConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl FileOpener for ZarrFileOpener {
+    fn open(
+        &self,
+        file_meta: datafusion::datasource::physical_plan::FileMeta,
+    ) -> datafusion::error::Result<datafusion::datasource::physical_plan::FileOpenFuture> {
+        let config = self.config.clone();
+
+        Ok(Box::pin(async move {
+            let zarr_path = ZarrPath::new(config.object_store, file_meta.object_meta.location);
+
+            let rng = file_meta.range.map(|r| (r.start as usize, r.end as usize));
+            let batch_reader = ZarrRecordBatchStreamBuilder::new(zarr_path)
+                .build_partial_reader(rng)
+                .await
+                .map_err(|_| {
+                    DataFusionError::Execution("Error creating zarr reader".to_string())
+                })?;
+
+            let stream = batch_reader
+                .map_err(|_| ArrowError::ComputeError("Error reading zarr".to_string()));
+
+            Ok(stream.boxed())
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use datafusion::datasource::physical_plan::FileMeta;
+    use object_store::{local::LocalFileSystem, path::Path, ObjectMeta};
+
+    use crate::tests::get_test_data_path;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_open() {
+        let local_fs = LocalFileSystem::new();
+
+        let test_data = get_test_data_path("lat_lon_example.zarr".to_string());
+
+        let config = ZarrConfig {
+            object_store: Arc::new(local_fs),
+        };
+
+        let opener = ZarrFileOpener::new(config);
+
+        let file_meta = FileMeta {
+            object_meta: ObjectMeta {
+                location: Path::from_filesystem_path(test_data).unwrap(),
+                last_modified: chrono::Utc::now(),
+                size: 0,
+                e_tag: None,
+                version: None,
+            },
+            range: None,
+            extensions: None,
+        };
+
+        let open_future = opener.open(file_meta).unwrap();
+
+        let stream = open_future.await.unwrap();
+
+        let batches: Vec<_> = stream.try_collect().await.unwrap();
+
+        assert_eq!(batches.len(), 9);
+    }
+}

--- a/src/datafusion/file_opener.rs
+++ b/src/datafusion/file_opener.rs
@@ -66,7 +66,7 @@ mod tests {
     use datafusion::datasource::physical_plan::FileMeta;
     use object_store::{local::LocalFileSystem, path::Path, ObjectMeta};
 
-    use crate::tests::get_test_data_path;
+    use crate::tests::get_test_v2_data_path;
 
     use super::*;
 
@@ -74,7 +74,7 @@ mod tests {
     async fn test_open() {
         let local_fs = LocalFileSystem::new();
 
-        let test_data = get_test_data_path("lat_lon_example.zarr".to_string());
+        let test_data = get_test_v2_data_path("lat_lon_example.zarr".to_string());
 
         let config = ZarrConfig {
             object_store: Arc::new(local_fs),

--- a/src/datafusion/mod.rs
+++ b/src/datafusion/mod.rs
@@ -1,0 +1,19 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+pub mod config;
+pub mod file_opener;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,16 @@ pub mod datafusion;
 mod tests {
     use std::path::PathBuf;
 
-    pub(crate) fn get_test_data_path(zarr_store: String) -> PathBuf {
+    #[cfg(feature = "datafusion")]
+    pub(crate) fn get_test_v2_data_path(zarr_store: String) -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("test-data/data/zarr/v2_data")
             .join(zarr_store)
+    }
+
+    pub(crate) fn get_test_v3_data_path(zarr_array: String) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("test-data/data/zarr/v3_data")
+            .join(zarr_array)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,16 @@
 pub mod async_reader;
 pub mod reader;
+
+#[cfg(feature = "datafusion")]
+pub mod datafusion;
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    pub(crate) fn get_test_data_path(zarr_store: String) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("test-data/data/zarr/v2_data")
+            .join(zarr_store)
+    }
+}

--- a/src/reader/codecs.rs
+++ b/src/reader/codecs.rs
@@ -785,7 +785,7 @@ pub(crate) fn apply_codecs(
 
 #[cfg(test)]
 mod zarr_codecs_tests {
-    use crate::tests::get_test_data_path;
+    use crate::tests::get_test_v3_data_path;
 
     use super::*;
     use ::std::fs::read;
@@ -794,7 +794,7 @@ mod zarr_codecs_tests {
     // doesn't included any sharding.
     #[test]
     fn no_sharding_tests() {
-        let path = get_test_data_path("no_sharding.zarr/int_data/c/1/1".to_string());
+        let path = get_test_v3_data_path("no_sharding.zarr/int_data/c/1/1".to_string());
         let raw_data = read(path).unwrap();
 
         let chunk_shape = vec![4, 4];
@@ -838,7 +838,7 @@ mod zarr_codecs_tests {
     // includes sharding.
     #[test]
     fn with_sharding_tests() {
-        let path = get_test_data_path("with_sharding.zarr/float_data/1.1".to_string());
+        let path = get_test_v3_data_path("with_sharding.zarr/float_data/1.1".to_string());
         let raw_data = read(path).unwrap();
 
         let chunk_shape = vec![4, 4];
@@ -890,7 +890,7 @@ mod zarr_codecs_tests {
     // includes sharding, and the shape doesn't exactly line up with the chunks.
     #[test]
     fn with_sharding_with_edge_tests() {
-        let path = get_test_data_path("with_sharding_with_edge.zarr/uint_data/1.1".to_string());
+        let path = get_test_v3_data_path("with_sharding_with_edge.zarr/uint_data/1.1".to_string());
         let raw_data = read(path).unwrap();
 
         let chunk_shape = vec![4, 4];

--- a/src/reader/codecs.rs
+++ b/src/reader/codecs.rs
@@ -785,15 +785,10 @@ pub(crate) fn apply_codecs(
 
 #[cfg(test)]
 mod zarr_codecs_tests {
+    use crate::tests::get_test_data_path;
+
     use super::*;
     use ::std::fs::read;
-    use std::path::PathBuf;
-
-    fn get_test_data_path(zarr_array: String) -> PathBuf {
-        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("test-data/data/zarr/v3_data")
-            .join(zarr_array)
-    }
 
     // reading a chunk and decoding it using hard coded, known options. this test
     // doesn't included any sharding.


### PR DESCRIPTION
This PR does a very basic implementation of the `FileOpener` trait in datafusion by a new `ZarrFileOpener`. In a follow up PR, I'll use the non-async zarr reader for the local file case as well as fill out other options (like projection).

Please let me know if you have any feedback.

Thanks!