### PR TITLE
feat: datafusion scanner

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           cargo fmt --all -- --check
 
-  check-clippy:
+  check-clippy-all-features:
     name: Check cargo clippy
     runs-on: ubuntu-latest
     container:
@@ -34,3 +34,18 @@ jobs:
       - name: Run check
         run: |
           cargo clippy --all-targets --all-features -- -D warnings
+
+  # Check clippy without features, helps to catch missing feature configurations
+  check-clippy-no-features:
+    name: Check cargo clippy
+    runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - name: Run check
+        run: |
+          cargo clippy --all-targets -- -D warnings

--- a/src/datafusion/config.rs
+++ b/src/datafusion/config.rs
@@ -21,19 +21,21 @@ use object_store::ObjectStore;
 
 const DEFAULT_BATCH_SIZE: usize = 8096;
 
+/// Configuration for Zarr DataFusion processing.
 #[derive(Clone)]
 pub struct ZarrConfig {
-    // The object store to use.
+    /// The object store to use.
     pub object_store: Arc<dyn ObjectStore>,
 
-    // The projection for the scan.
+    /// The projection for the scan.
     pub projection: Option<Vec<usize>>,
 
-    // The batch size for the scan.
+    /// The batch size for the scan.
     pub batch_size: usize,
 }
 
 impl ZarrConfig {
+    /// Create a new ZarrConfig.
     pub fn new(object_store: Arc<dyn ObjectStore>) -> Self {
         Self {
             object_store,
@@ -42,11 +44,13 @@ impl ZarrConfig {
         }
     }
 
+    /// Set the batch size for the scan.
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
         self
     }
 
+    /// Set the projection for the scan.
     pub fn with_projection(mut self, projection: Option<Vec<usize>>) -> Self {
         self.projection = projection;
         self

--- a/src/datafusion/config.rs
+++ b/src/datafusion/config.rs
@@ -19,8 +19,6 @@ use std::sync::Arc;
 
 use object_store::ObjectStore;
 
-const DEFAULT_BATCH_SIZE: usize = 8096;
-
 /// Configuration for Zarr DataFusion processing.
 #[derive(Clone)]
 pub struct ZarrConfig {
@@ -29,9 +27,6 @@ pub struct ZarrConfig {
 
     /// The projection for the scan.
     pub projection: Option<Vec<usize>>,
-
-    /// The batch size for the scan.
-    pub batch_size: usize,
 }
 
 impl ZarrConfig {
@@ -40,14 +35,7 @@ impl ZarrConfig {
         Self {
             object_store,
             projection: None,
-            batch_size: DEFAULT_BATCH_SIZE,
         }
-    }
-
-    /// Set the batch size for the scan.
-    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
-        self.batch_size = batch_size;
-        self
     }
 
     /// Set the projection for the scan.

--- a/src/datafusion/config.rs
+++ b/src/datafusion/config.rs
@@ -19,14 +19,36 @@ use std::sync::Arc;
 
 use object_store::ObjectStore;
 
+const DEFAULT_BATCH_SIZE: usize = 8096;
+
 #[derive(Clone)]
 pub struct ZarrConfig {
     // The object store to use.
     pub object_store: Arc<dyn ObjectStore>,
+
+    // The projection for the scan.
+    pub projection: Option<Vec<usize>>,
+
+    // The batch size for the scan.
+    pub batch_size: usize,
 }
 
 impl ZarrConfig {
     pub fn new(object_store: Arc<dyn ObjectStore>) -> Self {
-        Self { object_store }
+        Self {
+            object_store,
+            projection: None,
+            batch_size: DEFAULT_BATCH_SIZE,
+        }
+    }
+
+    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = batch_size;
+        self
+    }
+
+    pub fn with_projection(mut self, projection: Option<Vec<usize>>) -> Self {
+        self.projection = projection;
+        self
     }
 }

--- a/src/datafusion/file_opener.rs
+++ b/src/datafusion/file_opener.rs
@@ -19,7 +19,10 @@ use arrow_schema::ArrowError;
 use datafusion::{datasource::physical_plan::FileOpener, error::DataFusionError};
 use futures::{StreamExt, TryStreamExt};
 
-use crate::async_reader::{ZarrPath, ZarrRecordBatchStreamBuilder};
+use crate::{
+    async_reader::{ZarrPath, ZarrRecordBatchStreamBuilder},
+    reader::ZarrProjection,
+};
 
 use super::config::ZarrConfig;
 
@@ -44,7 +47,14 @@ impl FileOpener for ZarrFileOpener {
             let zarr_path = ZarrPath::new(config.object_store, file_meta.object_meta.location);
 
             let rng = file_meta.range.map(|r| (r.start as usize, r.end as usize));
+
+            let projection = match config.projection {
+                Some(ref p) => ZarrProjection::from(p.clone()),
+                None => ZarrProjection::all(),
+            };
+
             let batch_reader = ZarrRecordBatchStreamBuilder::new(zarr_path)
+                .with_projection(projection)
                 .build_partial_reader(rng)
                 .await
                 .map_err(|_| {

--- a/src/datafusion/mod.rs
+++ b/src/datafusion/mod.rs
@@ -17,3 +17,4 @@
 
 pub mod config;
 pub mod file_opener;
+pub mod scanner;

--- a/src/datafusion/scanner.rs
+++ b/src/datafusion/scanner.rs
@@ -44,7 +44,7 @@ use datafusion::{
 use super::{config::ZarrConfig, file_opener::ZarrFileOpener};
 
 #[derive(Debug, Clone)]
-/// Implements a datafusion `ExecutionPlan` for Genbank files.
+/// Implements a DataFusion `ExecutionPlan` for Genbank files.
 pub struct ZarrScan {
     /// The base configuration for the file scan.
     base_config: FileScanConfig,

--- a/src/datafusion/scanner.rs
+++ b/src/datafusion/scanner.rs
@@ -30,7 +30,7 @@ use datafusion::{
 use super::{config::ZarrConfig, file_opener::ZarrFileOpener};
 
 #[derive(Debug, Clone)]
-/// Implements a DataFusion `ExecutionPlan` for Genbank files.
+/// Implements a DataFusion `ExecutionPlan` for Zarr files.
 pub struct ZarrScan {
     /// The base configuration for the file scan.
     base_config: FileScanConfig,
@@ -46,7 +46,7 @@ pub struct ZarrScan {
 }
 
 impl ZarrScan {
-    /// Create a new Genbank scan.
+    /// Create a new Zarr scan.
     pub fn new(base_config: FileScanConfig) -> Self {
         let (projected_schema, statistics, _lex_sorting) = base_config.project();
 

--- a/src/datafusion/scanner.rs
+++ b/src/datafusion/scanner.rs
@@ -98,11 +98,8 @@ impl ExecutionPlan for ZarrScan {
             .runtime_env()
             .object_store(&self.base_config.object_store_url)?;
 
-        let batch_size = context.session_config().batch_size();
-
-        let config = ZarrConfig::new(object_store)
-            .with_batch_size(batch_size)
-            .with_projection(self.base_config.projection.clone());
+        let config =
+            ZarrConfig::new(object_store).with_projection(self.base_config.projection.clone());
 
         let opener = ZarrFileOpener::new(config);
 

--- a/src/datafusion/scanner.rs
+++ b/src/datafusion/scanner.rs
@@ -15,20 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Copyright 2023 WHERE TRUE Technologies.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 use std::{any::Any, sync::Arc};
 
 use arrow::datatypes::SchemaRef;

--- a/src/datafusion/scanner.rs
+++ b/src/datafusion/scanner.rs
@@ -1,0 +1,209 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Copyright 2023 WHERE TRUE Technologies.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{any::Any, sync::Arc};
+
+use arrow::datatypes::SchemaRef;
+use datafusion::{
+    common::Statistics,
+    datasource::physical_plan::{FileScanConfig, FileStream},
+    physical_plan::{
+        metrics::ExecutionPlanMetricsSet, DisplayAs, DisplayFormatType, ExecutionPlan,
+        Partitioning, SendableRecordBatchStream,
+    },
+};
+
+use super::{config::ZarrConfig, file_opener::ZarrFileOpener};
+
+#[derive(Debug, Clone)]
+/// Implements a datafusion `ExecutionPlan` for Genbank files.
+pub struct ZarrScan {
+    /// The base configuration for the file scan.
+    base_config: FileScanConfig,
+
+    /// The projected schema for the scan.
+    projected_schema: SchemaRef,
+
+    /// Metrics for the execution plan.
+    metrics: ExecutionPlanMetricsSet,
+
+    /// The statistics for the scan.
+    statistics: Statistics,
+}
+
+impl ZarrScan {
+    /// Create a new Genbank scan.
+    pub fn new(base_config: FileScanConfig) -> Self {
+        let (projected_schema, statistics, _lex_sorting) = base_config.project();
+
+        Self {
+            base_config,
+            projected_schema,
+            metrics: ExecutionPlanMetricsSet::new(),
+            statistics,
+        }
+    }
+}
+
+impl DisplayAs for ZarrScan {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "ZarrScan")
+    }
+}
+
+impl ExecutionPlan for ZarrScan {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.projected_schema.clone()
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn statistics(&self) -> datafusion::error::Result<Statistics> {
+        Ok(self.statistics.clone())
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<datafusion::execution::context::TaskContext>,
+    ) -> datafusion::error::Result<datafusion::physical_plan::SendableRecordBatchStream> {
+        let object_store = context
+            .runtime_env()
+            .object_store(&self.base_config.object_store_url)?;
+
+        let batch_size = context.session_config().batch_size();
+
+        let config = ZarrConfig::new(object_store)
+            .with_batch_size(batch_size)
+            .with_projection(self.base_config.projection.clone());
+
+        let opener = ZarrFileOpener::new(config);
+
+        let stream = FileStream::new(&self.base_config, partition, opener, &self.metrics)?;
+
+        Ok(Box::pin(stream) as SendableRecordBatchStream)
+    }
+
+    fn output_partitioning(&self) -> datafusion::physical_plan::Partitioning {
+        Partitioning::UnknownPartitioning(self.base_config.file_groups.len())
+    }
+
+    fn output_ordering(&self) -> Option<&[datafusion::physical_expr::PhysicalSortExpr]> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{error::Error, sync::Arc};
+
+    use datafusion::{
+        datasource::{listing::PartitionedFile, physical_plan::FileMeta},
+        execution::object_store::ObjectStoreUrl,
+    };
+    use futures::TryStreamExt;
+    use object_store::{local::LocalFileSystem, path::Path, ObjectMeta};
+
+    use crate::{
+        async_reader::{ZarrPath, ZarrReadAsync},
+        tests::get_test_v2_data_path,
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_open() -> Result<(), Box<dyn Error>> {
+        let local_fs = Arc::new(LocalFileSystem::new());
+
+        let test_data = get_test_v2_data_path("lat_lon_example.zarr".to_string());
+        let location = Path::from_filesystem_path(&test_data)?;
+
+        let file_meta = FileMeta {
+            object_meta: ObjectMeta {
+                location,
+                last_modified: chrono::Utc::now(),
+                size: 0,
+                e_tag: None,
+                version: None,
+            },
+            range: None,
+            extensions: None,
+        };
+
+        let zarr_path = ZarrPath::new(local_fs, file_meta.object_meta.location);
+        let schema = zarr_path.get_zarr_metadata().await?.arrow_schema()?;
+
+        let test_file = Path::from_filesystem_path(test_data)?;
+        let scan_config = FileScanConfig {
+            object_store_url: ObjectStoreUrl::local_filesystem(),
+            file_schema: Arc::new(schema.clone()),
+            file_groups: vec![vec![PartitionedFile::new(test_file.to_string(), 10)]],
+            statistics: Statistics::new_unknown(&schema),
+            projection: Some(vec![1, 2]),
+            limit: Some(10),
+            table_partition_cols: vec![],
+            output_ordering: vec![],
+        };
+
+        let scanner = ZarrScan::new(scan_config);
+
+        let session = datafusion::execution::context::SessionContext::new();
+
+        let batch_stream = scanner.execute(0, session.task_ctx())?;
+        let batches: Vec<_> = batch_stream.try_collect().await?;
+
+        assert_eq!(batches.len(), 1);
+
+        let first_batch = &batches[0];
+        assert_eq!(first_batch.num_columns(), 2);
+        assert_eq!(first_batch.num_rows(), 10);
+
+        let schema = first_batch.schema();
+
+        let names = schema.fields().iter().map(|f| f.name()).collect::<Vec<_>>();
+        assert_eq!(names, vec!["lon", "lat"]);
+
+        Ok(())
+    }
+}

--- a/src/reader/codecs.rs
+++ b/src/reader/codecs.rs
@@ -34,6 +34,34 @@ impl ZarrDataType {
             | Self::TimeStamp(s, _) => *s,
         }
     }
+
+    pub(crate) fn to_arrow_type(&self) -> ZarrResult<DataType> {
+        match self {
+            Self::Bool => Ok(DataType::Boolean),
+            Self::UInt(s) => match s {
+                1 => Ok(DataType::UInt8),
+                2 => Ok(DataType::UInt16),
+                4 => Ok(DataType::UInt32),
+                8 => Ok(DataType::UInt64),
+                _ => Err(throw_invalid_meta("Invalid uint size")),
+            },
+            Self::Int(s) => match s {
+                1 => Ok(DataType::Int8),
+                2 => Ok(DataType::Int16),
+                4 => Ok(DataType::Int32),
+                8 => Ok(DataType::Int64),
+                _ => Err(throw_invalid_meta("Invalid int size")),
+            },
+            Self::Float(s) => match s {
+                4 => Ok(DataType::Float32),
+                8 => Ok(DataType::Float64),
+                _ => Err(throw_invalid_meta("Invalid float size")),
+            },
+            Self::FixedLengthString(_) => Ok(DataType::Utf8),
+            Self::FixedLengthPyUnicode(_) => Ok(DataType::Utf8),
+            Self::TimeStamp(_, _) => todo!(),
+        }
+    }
 }
 
 // This is the byte length of the Py Unicode characters that zarr writes

--- a/src/reader/codecs.rs
+++ b/src/reader/codecs.rs
@@ -974,8 +974,43 @@ mod zarr_codecs_tests {
 
     #[test]
     fn test_zarr_data_type_to_arrow_datatype() -> ZarrResult<()> {
-        let zarr_types = vec![ZarrDataType::Bool, ZarrDataType::UInt(1)];
-        let exepcted_types = vec![DataType::Boolean, DataType::UInt8];
+        let zarr_types = [
+            ZarrDataType::Bool,
+            ZarrDataType::UInt(1),
+            ZarrDataType::UInt(2),
+            ZarrDataType::UInt(4),
+            ZarrDataType::UInt(8),
+            ZarrDataType::Int(1),
+            ZarrDataType::Int(2),
+            ZarrDataType::Int(4),
+            ZarrDataType::Int(8),
+            ZarrDataType::Float(4),
+            ZarrDataType::Float(8),
+            ZarrDataType::TimeStamp(8, "s".to_string()),
+            ZarrDataType::TimeStamp(8, "ms".to_string()),
+            ZarrDataType::TimeStamp(8, "us".to_string()),
+            ZarrDataType::TimeStamp(8, "ns".to_string()),
+        ];
+
+        let exepcted_types = [
+            DataType::Boolean,
+            DataType::UInt8,
+            DataType::UInt16,
+            DataType::UInt32,
+            DataType::UInt64,
+            DataType::Int8,
+            DataType::Int16,
+            DataType::Int32,
+            DataType::Int64,
+            DataType::Float32,
+            DataType::Float64,
+            DataType::Timestamp(TimeUnit::Second, None),
+            DataType::Timestamp(TimeUnit::Millisecond, None),
+            DataType::Timestamp(TimeUnit::Microsecond, None),
+            DataType::Timestamp(TimeUnit::Nanosecond, None),
+        ];
+
+        assert_eq!(zarr_types.len(), exepcted_types.len());
 
         for (zarr_type, expected_type) in zarr_types.iter().zip(exepcted_types.iter()) {
             let arrow_type = DataType::try_from(zarr_type)?;

--- a/src/reader/errors.rs
+++ b/src/reader/errors.rs
@@ -1,4 +1,5 @@
 use arrow_schema::ArrowError;
+use datafusion::error::DataFusionError;
 use object_store::Error as ObjStoreError;
 use std::error::Error;
 use std::io;
@@ -15,6 +16,7 @@ pub enum ZarrError {
     InvalidChunkRange(usize, usize, usize),
     Io(Box<dyn Error + Send + Sync>),
     Arrow(Box<dyn Error + Send + Sync>),
+    DataFusion(Box<dyn Error + Send + Sync>),
     ObjectStore(Box<dyn Error + Send + Sync>),
 }
 
@@ -37,7 +39,8 @@ impl std::fmt::Display for ZarrError {
             }
             ZarrError::Io(e) => write!(fmt, "IO error: {e}"),
             ZarrError::Arrow(e) => write!(fmt, "Arrow error: {e}"),
-            ZarrError::ObjectStore(e) => write!(fmt, "Arrow error: {e}"),
+            ZarrError::ObjectStore(e) => write!(fmt, "ObjectStore error: {e}"),
+            ZarrError::DataFusion(e) => write!(fmt, "DataFusion error: {e}"),
         }
     }
 }
@@ -65,6 +68,12 @@ impl From<ObjStoreError> for ZarrError {
 impl From<Utf8Error> for ZarrError {
     fn from(e: Utf8Error) -> ZarrError {
         ZarrError::InvalidMetadata(e.to_string())
+    }
+}
+
+impl From<DataFusionError> for ZarrError {
+    fn from(e: DataFusionError) -> ZarrError {
+        ZarrError::Arrow(Box::new(e))
     }
 }
 

--- a/src/reader/errors.rs
+++ b/src/reader/errors.rs
@@ -73,7 +73,7 @@ impl From<Utf8Error> for ZarrError {
 
 impl From<DataFusionError> for ZarrError {
     fn from(e: DataFusionError) -> ZarrError {
-        ZarrError::Arrow(Box::new(e))
+        ZarrError::DataFusion(Box::new(e))
     }
 }
 

--- a/src/reader/errors.rs
+++ b/src/reader/errors.rs
@@ -42,6 +42,8 @@ impl std::fmt::Display for ZarrError {
     }
 }
 
+impl Error for ZarrError {}
+
 impl From<io::Error> for ZarrError {
     fn from(e: io::Error) -> ZarrError {
         ZarrError::Io(Box::new(e))

--- a/src/reader/errors.rs
+++ b/src/reader/errors.rs
@@ -1,4 +1,5 @@
 use arrow_schema::ArrowError;
+#[cfg(feature = "datafusion")]
 use datafusion::error::DataFusionError;
 use object_store::Error as ObjStoreError;
 use std::error::Error;
@@ -71,6 +72,7 @@ impl From<Utf8Error> for ZarrError {
     }
 }
 
+#[cfg(feature = "datafusion")]
 impl From<DataFusionError> for ZarrError {
     fn from(e: DataFusionError) -> ZarrError {
         ZarrError::DataFusion(Box::new(e))

--- a/src/reader/metadata.rs
+++ b/src/reader/metadata.rs
@@ -3,7 +3,7 @@ use crate::reader::codecs::{
     ShuffleOptions, ZarrCodec, ZarrDataType, PY_UNICODE_SIZE,
 };
 use crate::reader::{ZarrError, ZarrResult};
-use arrow_schema::{Field, Schema};
+use arrow_schema::{DataType, Field, Schema};
 use itertools::Itertools;
 use regex::Regex;
 use serde_json::{json, Value};
@@ -212,7 +212,7 @@ impl ZarrStoreMetadata {
                     "could not find metadata for column".to_string(),
                 ))?;
 
-            let data_type = meta.get_type().to_arrow_type()?;
+            let data_type = DataType::try_from(meta.get_type())?;
             let field = Field::new(col, data_type, true);
             fields.push(field);
         }

--- a/src/reader/metadata.rs
+++ b/src/reader/metadata.rs
@@ -1046,6 +1046,11 @@ mod zarr_metadata_v3_tests {
         assert_eq!(meta.last_chunk_idx, Some(vec![3, 3]));
         assert_eq!(meta.columns, vec!["var1"]);
 
+        let arrow_schema = meta.arrow_schema().unwrap();
+        assert_eq!(arrow_schema.fields().len(), 1);
+        assert_eq!(arrow_schema.field(0).name(), "var1");
+        assert_eq!(arrow_schema.field(0).data_type(), &DataType::Int32);
+
         assert_eq!(
             meta.array_params["var1"],
             ZarrArrayMetadata {
@@ -1106,6 +1111,11 @@ mod zarr_metadata_v3_tests {
         assert_eq!(meta.shape, Some(vec![16, 16]));
         assert_eq!(meta.last_chunk_idx, Some(vec![1, 1]));
         assert_eq!(meta.columns, vec!["var2"]);
+
+        let arrow_schema = meta.arrow_schema().unwrap();
+        assert_eq!(arrow_schema.fields().len(), 1);
+        assert_eq!(arrow_schema.field(0).name(), "var2");
+        assert_eq!(arrow_schema.field(0).data_type(), &DataType::Int32);
 
         assert_eq!(
             meta.array_params["var2"],

--- a/src/reader/zarr_read.rs
+++ b/src/reader/zarr_read.rs
@@ -82,9 +82,12 @@ impl From<Vec<usize>> for ZarrProjection {
     }
 }
 
-impl From<Vec<String>> for ZarrProjection {
-    fn from(names: Vec<String>) -> Self {
-        Self::keep(names)
+impl From<Option<&Vec<usize>>> for ZarrProjection {
+    fn from(indices: Option<&Vec<usize>>) -> Self {
+        match indices {
+            Some(i) => Self::keep_by_index(i.to_vec()),
+            None => Self::all(),
+        }
     }
 }
 


### PR DESCRIPTION
This adds a Scanner implementation, which is getting closer to the actual table provider. I also made a couple of other changes as part of this:

* Updated the Projection to support selecting by index which is more inline with how datafusion passes projection info around.
* Added `arrow_schema` to support getting the arrow schema from the metadata
* Updated `ZarrError` to implement `Error`.