### PR TITLE
Try loading xenium zarr

### DIFF
--- a/src/datafusion/table_factory.rs
+++ b/src/datafusion/table_factory.rs
@@ -120,6 +120,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_zarr() -> Result<(), Box<dyn std::error::Error>> {
+        let mut state = SessionState::new_with_config_rt(
+            SessionConfig::default(),
+            Arc::new(RuntimeEnv::default()),
+        );
+
+        state
+            .table_factories_mut()
+            .insert("ZARR".into(), Arc::new(super::ZarrListingTableFactory {}));
+
+        let test_data = "data.zarr";
+
+        let sql = format!(
+            "CREATE EXTERNAL TABLE zarr_table STORED AS ZARR LOCATION '{}'",
+            test_data,
+        );
+
+        let session = SessionContext::new_with_state(state);
+        session.sql(&sql).await?;
+
+        let sql = "SELECT * FROM zarr_table LIMIT 10";
+        let df = session.sql(sql).await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_predicates() -> Result<(), Box<dyn std::error::Error>> {
         let mut state = SessionState::new_with_config_rt(
             SessionConfig::default(),


### PR DESCRIPTION
This is more a scratch work spot then a PR, but I may peel off things from here if we thing they're useful.

I tried loading a xenium dataset and am getting an error that looks to be an issue with the `chunks` key in the metadata changing values... `Error: Execution("infer error: InvalidMetadata(\"inconsistent chunks in metadata, got [313] but have [41945, 1]\")")`.

* data is here: https://github.com/giovp/spatialdata-sandbox/tree/main/xenium_rep1_io
* example usage is here: https://spatialdata.scverse.org/en/latest/tutorials/notebooks/notebooks/examples/squidpy_integration.html