### PR TITLE
One dim reads

### DIFF
--- a/src/datafusion/helpers.rs
+++ b/src/datafusion/helpers.rs
@@ -247,13 +247,9 @@ pub(crate) fn build_row_filter(
     let candidates: Vec<ZarrFilterCandidate> = predicates
         .into_iter()
         .flat_map(|expr| {
-            if let Ok(candidate) =
-                ZarrFilterCandidateBuilder::new(expr.clone(), file_schema).build()
-            {
-                candidate
-            } else {
-                None
-            }
+            ZarrFilterCandidateBuilder::new(expr.clone(), file_schema)
+                .build()
+                .unwrap_or_default()
         })
         .collect();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,6 @@ mod tests {
     use object_store::local::LocalFileSystem;
     use std::path::PathBuf;
 
-    #[cfg(feature = "datafusion")]
     pub(crate) fn get_test_v2_data_path(zarr_store: String) -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("test-data/data/zarr/v2_data")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod datafusion;
 
 #[cfg(test)]
 mod tests {
+    use object_store::local::LocalFileSystem;
     use std::path::PathBuf;
 
     #[cfg(feature = "datafusion")]
@@ -36,5 +37,19 @@ mod tests {
         PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("test-data/data/zarr/v3_data")
             .join(zarr_array)
+    }
+
+    pub(crate) fn get_test_v2_data_file_system() -> LocalFileSystem {
+        LocalFileSystem::new_with_prefix(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test-data/data/zarr/v2_data"),
+        )
+        .unwrap()
+    }
+
+    pub(crate) fn get_test_v3_data_file_system() -> LocalFileSystem {
+        LocalFileSystem::new_with_prefix(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test-data/data/zarr/v3_data"),
+        )
+        .unwrap()
     }
 }

--- a/src/reader/metadata.rs
+++ b/src/reader/metadata.rs
@@ -413,7 +413,7 @@ impl ZarrStoreMetadata {
         }
 
         // the index of the last chunk in each dimension
-        if self.last_chunk_idx.is_none() {
+        if self.last_chunk_idx.is_none() && one_dim_repr.is_none() {
             self.last_chunk_idx = Some(
                 chunks
                     .iter()
@@ -849,14 +849,8 @@ impl ZarrStoreMetadata {
 
     pub(crate) fn get_one_dim_repr_meta(
         &self,
-        column: &str,
-    ) -> ZarrResult<&(usize, String, ZarrArrayMetadata)> {
-        self.one_dim_representations
-            .get(column)
-            .ok_or(ZarrError::InvalidMetadata(format!(
-                "Cannot find variable {} in one dimensional representations",
-                column
-            )))
+    ) -> &HashMap<String, (usize, String, ZarrArrayMetadata)> {
+        &self.one_dim_representations
     }
 
     // return the real dimensions of a chhunk, given its position, taking into


### PR DESCRIPTION
So this is a more experimental feature I've been wanting to try. Since often times the "coordinate" part of the data involves duplicating some data, e.g. if x only varies along one dimension, but the rest of the data is 2D or 3D, x ends up being replicated to be 2D or 3D, I thought it would be nice if mixing array sizes was supported, e.g. x has 10000 pts, 10 chunks, y has 15000 pts, 15 chunks, and the rest of the data has 10 x 15 chunks, 10000 pts by 15000 pts. Then when reading the data, it is replicated on the fly, that way you end up reading less data, especially with filter push downs, if the conditions are on those variables (x and y). The attributes are used to indicate that e.g. a 1D array is to be replicated when read.

In this PR, I didn't quite do that, it's more like something you can add to existing data, e.g. you already have x as a 2D array but you can upload a 1D array, a one dimensional "representation", and indicate via the attributes that this one should be read instead of the 2D one.

In a simple test where I read a decent amount of 2D data, in particular if I apply a filter, the time to read everything went from 12-13 secs to 8-9 secs, and the performance gain is probably better for 3D data. For now it's just a thing I wanted to add, I can probably clean this up later and simply support uploading different array shapes (provided the number of chunks and points match in all dimensions of course).