### PR TITLE
Store Arc<Schema> instead of Schema to reduce cloning overhead

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,9 +26,7 @@ mod test_utils {
     use arrow_array::cast::AsArray;
     use arrow_array::types::*;
     use arrow_array::RecordBatch;
-    use arrow_schema::DataType as ArrowDataType;
-    use arrow_schema::Field;
-    use arrow_schema::Schema;
+    use arrow_schema::{DataType as ArrowDataType, Field, Schema, SchemaRef};
     use futures::executor::block_on;
     use itertools::enumerate;
     use ndarray::{Array, Array1, Array2};
@@ -203,7 +201,7 @@ mod test_utils {
         write_data: bool,
         fillvalue: f64,
         dir_name: &str,
-    ) -> (StoreWrapper, Schema) {
+    ) -> (StoreWrapper, SchemaRef) {
         let wrapper = StoreWrapper::new(dir_name.into());
         let store = wrapper.get_store();
 
@@ -249,11 +247,11 @@ mod test_utils {
         )
         .await;
 
-        let schema = Schema::new(vec![
+        let schema = Arc::new(Schema::new(vec![
             Field::new("data", ArrowDataType::Float64, false),
             Field::new("lat", ArrowDataType::Float64, false),
             Field::new("lon", ArrowDataType::Float64, false),
-        ]);
+        ]));
 
         (wrapper, schema)
     }

--- a/src/table/config.rs
+++ b/src/table/config.rs
@@ -1,4 +1,4 @@
-use arrow_schema::Schema;
+use arrow_schema::SchemaRef;
 use std::fmt;
 use std::sync::Arc;
 use zarrs_storage::AsyncReadableListableStorageTraits;
@@ -11,7 +11,7 @@ pub struct ZarrConfig {
 
     /// The schema for the entire table (regardless of what columns
     /// are selected).
-    pub schema: Schema,
+    pub schema: SchemaRef,
 
     /// The projection for the scan.
     pub projection: Option<Vec<usize>>,
@@ -29,7 +29,7 @@ impl ZarrConfig {
     /// Create a new ZarrConfig.
     pub fn new(
         zarr_store: Arc<dyn AsyncReadableListableStorageTraits + Unpin + Send>,
-        schema: Schema,
+        schema: SchemaRef,
     ) -> Self {
         Self {
             zarr_store,

--- a/src/table/scanner.rs
+++ b/src/table/scanner.rs
@@ -85,9 +85,8 @@ pub struct ZarrScan {
 
 impl ZarrScan {
     pub(crate) fn new(zarr_config: ZarrConfig, filters: Option<Arc<dyn PhysicalExpr>>) -> Self {
-        let schema_ref = Arc::new(zarr_config.schema.clone());
         let plan_properties = PlanProperties::new(
-            EquivalenceProperties::new(schema_ref),
+            EquivalenceProperties::new(zarr_config.schema.clone()),
             Partitioning::UnknownPartitioning(1),
             EmissionType::Incremental,
             Boundedness::Bounded,
@@ -149,7 +148,7 @@ impl ExecutionPlan for ZarrScan {
         _context: Arc<datafusion::execution::TaskContext>,
     ) -> datafusion::error::Result<SendableRecordBatchStream> {
         let zarr_store = self.zarr_config.zarr_store.clone();
-        let schema_ref = Arc::new(self.zarr_config.schema.clone());
+        let schema_ref = self.zarr_config.schema.clone();
         let schema_ref_for_future = schema_ref.clone();
         let n_partitions = match self.plan_properties.partitioning {
             Partitioning::UnknownPartitioning(n) => n,

--- a/src/table/table_provider.rs
+++ b/src/table/table_provider.rs
@@ -11,6 +11,7 @@ use datafusion::logical_expr::CreateExternalTable;
 use datafusion::logical_expr::Expr;
 use datafusion::physical_plan::ExecutionPlan;
 use object_store::local::LocalFileSystem;
+use std::any::Any;
 use std::fmt::Debug;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -23,7 +24,7 @@ use zarrs_storage::{AsyncReadableListableStorageTraits, StorePrefix};
 
 /// The table provider for zarr stores.
 pub struct ZarrTable {
-    table_schema: Schema,
+    table_schema: SchemaRef,
     zarr_storage: Arc<dyn AsyncReadableListableStorageTraits + Unpin + Send>,
 }
 
@@ -35,7 +36,7 @@ impl Debug for ZarrTable {
 
 impl ZarrTable {
     pub fn new(
-        table_schema: Schema,
+        table_schema: SchemaRef,
         zarr_storage: Arc<dyn AsyncReadableListableStorageTraits + Unpin + Send>,
     ) -> Self {
         Self {
@@ -47,12 +48,12 @@ impl ZarrTable {
 
 #[async_trait]
 impl TableProvider for ZarrTable {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn Any {
         self
     }
 
     fn schema(&self) -> SchemaRef {
-        Arc::new(self.table_schema.clone())
+        self.table_schema.clone()
     }
 
     fn table_type(&self) -> TableType {
@@ -127,15 +128,7 @@ impl TableProviderFactory for ZarrTableFactory {
         } else {
             let provided_schema: Schema = cmd.schema.as_ref().into();
             for field in provided_schema.fields() {
-                let target_type = inferred_schema
-                    .fields()
-                    .find(field.name())
-                    .ok_or(DataFusionError::Execution(format!(
-                        "Requested column {} is missing from store",
-                        field.name()
-                    )))?
-                    .1
-                    .data_type();
+                let target_type = inferred_schema.field_with_name(field.name())?.data_type();
                 if field.data_type() != target_type {
                     return Err(DataFusionError::Execution(format!(
                         "Requested column {}'s type does not match data from store",
@@ -147,7 +140,7 @@ impl TableProviderFactory for ZarrTableFactory {
             provided_schema
         };
 
-        let table_provider = ZarrTable::new(schema, store);
+        let table_provider = ZarrTable::new(Arc::new(schema), store);
         Ok(Arc::new(table_provider))
     }
 }

--- a/src/zarr_store_opener/zarr_data_stream.rs
+++ b/src/zarr_store_opener/zarr_data_stream.rs
@@ -943,7 +943,7 @@ mod zarr_stream_tests {
         let (wrapper, schema) = get_lat_lon_data_store(true, 0.0, "lat_lon_data").await;
         let store = wrapper.get_store();
 
-        let stream = ZarrRecordBatchStream::new(store, Arc::new(schema), None, None, 1, 0)
+        let stream = ZarrRecordBatchStream::new(store, schema, None, None, 1, 0)
             .await
             .unwrap();
         let records: Vec<_> = stream.try_collect().await.unwrap();
@@ -1017,7 +1017,7 @@ mod zarr_stream_tests {
             get_lat_lon_data_store(false, fillvalue, "lat_lon_empty_data").await;
         let store = wrapper.get_store();
 
-        let stream = ZarrRecordBatchStream::new(store, Arc::new(schema), None, None, 1, 0)
+        let stream = ZarrRecordBatchStream::new(store, schema, None, None, 1, 0)
             .await
             .unwrap();
         let records: Vec<_> = stream.try_collect().await.unwrap();
@@ -1058,15 +1058,14 @@ mod zarr_stream_tests {
             ("data".to_string(), DataType::Float64),
         ]);
 
-        let stream =
-            ZarrRecordBatchStream::new(store.clone(), Arc::new(schema.clone()), None, None, 2, 0)
-                .await
-                .unwrap();
+        let stream = ZarrRecordBatchStream::new(store.clone(), schema.clone(), None, None, 2, 0)
+            .await
+            .unwrap();
         let records: Vec<_> = stream.try_collect().await.unwrap();
         validate_names_and_types(&target_types, &records[0]);
         assert_eq!(records.len(), 5);
 
-        let stream = ZarrRecordBatchStream::new(store, Arc::new(schema), None, None, 2, 1)
+        let stream = ZarrRecordBatchStream::new(store, schema, None, None, 2, 1)
             .await
             .unwrap();
         let records: Vec<_> = stream.try_collect().await.unwrap();
@@ -1103,28 +1102,25 @@ mod zarr_stream_tests {
         // there are only 9 chunks, asking for 20 partitions, so each partition up to
         // the 9th parittion should have one batch in them, after that there should be
         // no data returned by the streams.
-        let stream =
-            ZarrRecordBatchStream::new(store.clone(), Arc::new(schema.clone()), None, None, 20, 0)
-                .await
-                .unwrap();
+        let stream = ZarrRecordBatchStream::new(store.clone(), schema.clone(), None, None, 20, 0)
+            .await
+            .unwrap();
         let records: Vec<_> = stream.try_collect().await.unwrap();
         assert_eq!(records.len(), 1);
 
-        let stream =
-            ZarrRecordBatchStream::new(store.clone(), Arc::new(schema.clone()), None, None, 20, 8)
-                .await
-                .unwrap();
+        let stream = ZarrRecordBatchStream::new(store.clone(), schema.clone(), None, None, 20, 8)
+            .await
+            .unwrap();
         let records: Vec<_> = stream.try_collect().await.unwrap();
         assert_eq!(records.len(), 1);
 
-        let stream =
-            ZarrRecordBatchStream::new(store.clone(), Arc::new(schema.clone()), None, None, 20, 10)
-                .await
-                .unwrap();
+        let stream = ZarrRecordBatchStream::new(store.clone(), schema.clone(), None, None, 20, 10)
+            .await
+            .unwrap();
         let records: Vec<_> = stream.try_collect().await.unwrap();
         assert_eq!(records.len(), 0);
 
-        let stream = ZarrRecordBatchStream::new(store, Arc::new(schema), None, None, 20, 19)
+        let stream = ZarrRecordBatchStream::new(store, schema, None, None, 20, 19)
             .await
             .unwrap();
         let records: Vec<_> = stream.try_collect().await.unwrap();


### PR DESCRIPTION
This is pretty minor. Cloning an `Arc<Schema>` is cheaper (O(1)) than cloning a Schema (`O(n)`). From elsewhere in Arrow/DataFusion code, I believe they tend to put a schema into an `Arc` as early as possible so that any cloning is only done through the `Arc`.