### PR TITLE
refactor: Simplify implementation of `ZarrRecordBatchStream`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = "1.85"
 arrow = { version = "55.2.0" }
 arrow-array = { version = "55.2.0" }
 arrow-schema = { version = "55.2.0" }
+async-stream = "0.3"
 async-trait = { version = "0.1.89" }
 bytes = { version = "1.10.1" }
 datafusion = { version = "49.0.0" }
@@ -28,11 +29,7 @@ zarrs_metadata = { version = "0.3.4" }
 zarrs_object_store = { version = "0.4.0" }
 zarrs_storage = { version = "0.3.0", features = ["async"] }
 
-[features]
-
-all = []
 
 [dev-dependencies]
 ndarray = { version = "^0.16.1" }
 walkdir = { version = "2.5.0" }
-

--- a/src/errors/zarr_errors.rs
+++ b/src/errors/zarr_errors.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use arrow::error::ArrowError;
+use datafusion::error::DataFusionError;
 use std::error::Error;
 use zarrs::array::codec::CodecError;
 use zarrs::array::{ArrayCreateError, ArrayError};
@@ -98,5 +99,11 @@ pub type ZarrQueryResult<T, E = ZarrQueryError> = Result<T, E>;
 impl From<ZarrQueryError> for ArrowError {
     fn from(e: ZarrQueryError) -> ArrowError {
         ArrowError::ExternalError(Box::new(e))
+    }
+}
+
+impl From<ZarrQueryError> for DataFusionError {
+    fn from(e: ZarrQueryError) -> DataFusionError {
+        DataFusionError::External(Box::new(e))
     }
 }

--- a/src/errors/zarr_errors.rs
+++ b/src/errors/zarr_errors.rs
@@ -94,3 +94,9 @@ impl From<std::io::Error> for ZarrQueryError {
 
 /// A specialized [`Result`] for [`ZarrError`]s.
 pub type ZarrQueryResult<T, E = ZarrQueryError> = Result<T, E>;
+
+impl From<ZarrQueryError> for ArrowError {
+    fn from(e: ZarrQueryError) -> ArrowError {
+        ArrowError::ExternalError(Box::new(e))
+    }
+}

--- a/src/table/scanner.rs
+++ b/src/table/scanner.rs
@@ -162,7 +162,7 @@ impl ExecutionPlan for ZarrScan {
 
         let projection = self.zarr_config.projection.clone();
         let stream: FileOpenFuture = Box::pin(async move {
-            let inner_stream = ZarrRecordBatchStream::new(
+            let inner_stream = ZarrRecordBatchStream::try_new(
                 zarr_store,
                 schema_ref_for_future,
                 None,
@@ -174,9 +174,8 @@ impl ExecutionPlan for ZarrScan {
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
             Ok(inner_stream.boxed())
         });
-        let stream = StreamWrapper::new(stream, schema_ref);
-
-        Ok(Box::pin(stream))
+        let adapter = StreamWrapper::new(stream, schema_ref);
+        Ok(Box::pin(adapter))
     }
 }
 

--- a/src/zarr_store_opener/filter.rs
+++ b/src/zarr_store_opener/filter.rs
@@ -61,10 +61,9 @@ impl ZarrChunkFilter {
         }
     }
 
-    /// Get the schema for the combination of all the columns
-    /// needed to evaluate the filter.
-    pub fn get_schema_ref(&self) -> SchemaRef {
-        self.schema_ref.clone()
+    /// A reference to the schema for the columns needed to evaluate the filter.
+    pub fn schema_ref(&self) -> &SchemaRef {
+        &self.schema_ref
     }
 
     pub fn evaluate(&mut self, rec_batch: &RecordBatch) -> Result<bool, ArrowError> {

--- a/src/zarr_store_opener/zarr_data_stream.rs
+++ b/src/zarr_store_opener/zarr_data_stream.rs
@@ -813,16 +813,8 @@ impl<T: AsyncReadableListableStorageTraits + ?Sized + 'static> ZarrRecordBatchSt
     fn into_stream(mut self) -> ZarrRecordBatchStream {
         let schema = self.projected_schema_ref.clone();
         let stream = Box::pin(try_stream! {
-            loop {
-                let maybe_batch = self.next_chunk().await.map_err(|e| {
-                    ArrowError::ExternalError(Box::new(e))
-                })?;
-
-                if let Some(batch) = maybe_batch {
-                    yield batch;
-                } else {
-                    break;
-                }
+            while let Some(batch) = self.next_chunk().await? {
+                yield batch;
             }
         });
         ZarrRecordBatchStream { stream, schema }


### PR DESCRIPTION
The existing implementation 

### Change list

- The existing implementation of `ZarrRecordBatchStream` is pretty low level. It manually implements polling and is pretty hard to follow. The rust async/await ecosystem is a lot easier to implement and read, so I'm inclined to try and use it as much as possible.
- Adds dependency on [`async-stream`](https://docs.rs/async-stream/latest/async_stream/) so that we can easily convert from async iterator to stream. This gives higher-level code. Now it's clearer that the logic to actually read the next chunk of the async iterator is only ~10 lines of code.
- 
- Avoid returning `self` and `chunk_index` from `get_chunk`; instead returning only the loaded data.
- Implements conversions from `ZarrQueryError` into `ArrowError` and `DataFusionError`. This means we can use `?` instead of `.map_err(|err| ArrowError::External(Box::new(err)))`.
- Rename `get_schema_ref` to `schema_ref` and return a `&SchemaRef` to align with [upstream `RecordBatch` APIs](https://docs.rs/arrow/latest/arrow/array/struct.RecordBatch.html#method.schema_ref).
- 