### PR TITLE
Fixe to get logical plans (schemas) working.

### DIFF
--- a/src/table/config.rs
+++ b/src/table/config.rs
@@ -52,6 +52,18 @@ impl ZarrTableConfig {
     pub(crate) fn get_schema_ref(&self) -> SchemaRef {
         self.schema_ref.clone()
     }
+
+    pub(crate) fn get_projected_schema_ref(&self) -> SchemaRef {
+        if let Some(projection) = &self.projection {
+            let projected_fields: Fields = projection
+                .iter()
+                .map(|&i| self.schema_ref.field(i).clone())
+                .collect();
+            Arc::new(Schema::new(projected_fields))
+        } else {
+            self.schema_ref.clone()
+        }
+    }
 }
 
 /// We can create a table based on a directory with a supported zarr

--- a/src/table/scanner.rs
+++ b/src/table/scanner.rs
@@ -31,7 +31,7 @@ impl ZarrScan {
         _filters: Option<Arc<dyn PhysicalExpr>>,
     ) -> Self {
         let plan_properties = PlanProperties::new(
-            EquivalenceProperties::new(zarr_config.get_schema_ref()),
+            EquivalenceProperties::new(zarr_config.get_projected_schema_ref()),
             Partitioning::UnknownPartitioning(1),
             EmissionType::Incremental,
             Boundedness::Bounded,


### PR DESCRIPTION
The table scan should get the _projected_ schema (i.e. "logical schema"), not the default schema (i.e. "physical schema").